### PR TITLE
Bug #2180, Optionally extract the quiz ID from the URL - SlickQuiz

### DIFF
--- a/php/slickquiz-front.php
+++ b/php/slickquiz-front.php
@@ -293,6 +293,17 @@ if ( !class_exists( 'SlickQuizFront' ) ) {
                 'id' => 0,
             ), $atts ) );
 
+            // Optionally, extract quiz ID from the URL [Ticket #2180]
+            if ( 'url' == $id || 'uri' == $id || -1 == $id ) {
+                $regex = '@'. basename( get_permalink() ) .'\/(\d+)\/?@';
+
+                if ( preg_match($regex, $_SERVER['REQUEST_URI'], $matches) ) {
+                    $id = $matches[1];
+                }
+            }
+            // Guard against mis-spellings (plus security).
+            $id = intval( $id );
+
             $out = $this->show_slickquiz( $id );
 
             return $out;


### PR DESCRIPTION
- (Commit attempt 2, https://github.com/jewlofthelotus/SlickQuiz-WordPress fork)
- A backwards compatible change, that guards against mis-spellings
- Shortcode pattern(s):  [slickquiz id=url], [slickquiz id=(url|uri|-1)]
- https://plugins.trac.wordpress.org/ticket/2180
