### PR TITLE
Optionally extract quiz ID from a custom field

### DIFF
--- a/php/slickquiz-front.php
+++ b/php/slickquiz-front.php
@@ -307,6 +307,13 @@ if ( !class_exists( 'SlickQuizFront' ) ) {
                     $id = $matches[1];
                 }
             }
+            
+            // Optionally, extract quiz ID from a custom field 
+            if ($id == 'custom'){
+                $custom_value = get_post_meta(get_the_id(), 'slickquiz', 'true');
+                $id = $custom_value;
+            }
+
             // Guard against mis-spellings (plus security).
             $id = intval( $id );
 


### PR DESCRIPTION
This code change allows the quiz ID to be specified from a custom field from a post.

This has allowed me to put Slickquiz in a sidebar which calls different quizzes depending on the page. (for my purposes I've fixed it in the sidebar so comprehension questions are always visible on the side when scrolling through an article).

In order to activate the quizzes, you need to put 'custom' in the shortcode and 'slickquiz' as a key (with the value equating the id of the Slickquiz) in a custom field.

![custom-id-shortcode1](https://cloud.githubusercontent.com/assets/9849145/7446067/d85a3b34-f1cb-11e4-9171-7c7df3c616b8.png)
![example-quiz-sidebar](https://cloud.githubusercontent.com/assets/9849145/7446068/d85dfb98-f1cb-11e4-8f79-bbcc6a7aa6ce.png)
![slickquiz-custom-field](https://cloud.githubusercontent.com/assets/9849145/7446069/d85ee83c-f1cb-11e4-9b88-adfb955c7cc4.png)

Note: this is my first ever attempt at coding something for 'real' purposes or using github to make changes!
